### PR TITLE
Util optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ criterion = "0.2"
 env_logger = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 diesel = { version = "2", features = ["sqlite", "postgres", "mysql"] }
+rand = "0.8.5"
 
 [dependencies]
 typenum = "1"

--- a/benches/string.rs
+++ b/benches/string.rs
@@ -89,13 +89,6 @@ fn small_clone_benchmark(c: &mut Criterion) {
     c.bench_function("small clone", move |b| b.iter(|| string.clone()));
 }
 
-fn small_from_unchecked_benchmark(c: &mut Criterion) {
-    let string = "rrssttuuvvwwxxyyzza";
-    c.bench_function("small from unchecked", move |b| {
-        b.iter(|| unsafe { SmallString::from_str_unchecked(&string) })
-    });
-}
-
 fn small_from_truncate_benchmark(c: &mut Criterion) {
     let string = "bbbcccdddeeefffgggh";
     c.bench_function("small from truncate", move |b| {
@@ -107,16 +100,6 @@ fn small_try_from_benchmark(c: &mut Criterion) {
     let string = "iiijjjkkklllmmmnnnoo";
     c.bench_function("small try from", move |b| {
         b.iter(|| SmallString::try_from_str(&string))
-    });
-}
-
-fn small_push_str_unchecked_benchmark(c: &mut Criterion) {
-    let mut string = SmallString::default();
-    c.bench_function("small push str unchecked", move |b| {
-        b.iter(|| unsafe {
-            string.push_str_unchecked("1413121110987654321");
-            string.clear();
-        })
     });
 }
 
@@ -145,13 +128,6 @@ fn cache_clone_benchmark(c: &mut Criterion) {
     c.bench_function("cache clone", move |b| b.iter(|| string.clone()));
 }
 
-fn cache_from_unchecked_benchmark(c: &mut Criterion) {
-    let string = "wwwxxxyyyzzzaaaabbbb";
-    c.bench_function("cache from unchecked", move |b| {
-        b.iter(|| unsafe { CacheString::from_str_unchecked(&string) })
-    });
-}
-
 fn cache_from_truncate_benchmark(c: &mut Criterion) {
     let string = "ccccddddeeeeffffggggh";
     c.bench_function("cache from truncate", move |b| {
@@ -163,16 +139,6 @@ fn cache_try_from_benchmark(c: &mut Criterion) {
     let string = "iiiijjjjkkkkllllmmmmn";
     c.bench_function("cache try from", move |b| {
         b.iter(|| CacheString::try_from_str(&string))
-    });
-}
-
-fn cache_push_str_unchecked_benchmark(c: &mut Criterion) {
-    let mut string = CacheString::default();
-    c.bench_function("cache push str unchecked", move |b| {
-        b.iter(|| unsafe {
-            string.push_str_unchecked("1413121110987654321");
-            string.clear();
-        })
     });
 }
 
@@ -201,13 +167,6 @@ fn max_clone_benchmark(c: &mut Criterion) {
     c.bench_function("max clone", move |b| b.iter(|| string.clone()));
 }
 
-fn max_from_unchecked_benchmark(c: &mut Criterion) {
-    let string = "vvvvwwwwxxxxyyyzzzza";
-    c.bench_function("max from unchecked", move |b| {
-        b.iter(|| unsafe { MaxString::from_str_unchecked(&string) })
-    });
-}
-
 fn max_from_truncate_benchmark(c: &mut Criterion) {
     let string = "bbbbccccddddeeeeffff";
     c.bench_function("max from truncate", move |b| {
@@ -219,16 +178,6 @@ fn max_try_from_benchmark(c: &mut Criterion) {
     let string = "gggghhhhiiiijjjjkkkk";
     c.bench_function("max try from", move |b| {
         b.iter(|| MaxString::try_from_str(&string).unwrap())
-    });
-}
-
-fn max_push_str_unchecked_benchmark(c: &mut Criterion) {
-    let mut string = MaxString::default();
-    c.bench_function("max push str unchecked", move |b| {
-        b.iter(|| unsafe {
-            string.push_str_unchecked("1413121110987654321");
-            string.clear();
-        })
     });
 }
 
@@ -279,30 +228,24 @@ criterion_group!(
     small,
     small_clone_benchmark,
     small_try_from_benchmark,
-    small_from_unchecked_benchmark,
     small_from_truncate_benchmark,
     small_try_push_str_benchmark,
-    small_push_str_unchecked_benchmark,
     small_push_str_benchmark,
 );
 criterion_group!(
     cache,
     cache_clone_benchmark,
     cache_try_from_benchmark,
-    cache_from_unchecked_benchmark,
     cache_from_truncate_benchmark,
     cache_try_push_str_benchmark,
-    cache_push_str_unchecked_benchmark,
     cache_push_str_benchmark,
 );
 criterion_group!(
     max,
     max_clone_benchmark,
     max_try_from_benchmark,
-    max_from_unchecked_benchmark,
     max_from_truncate_benchmark,
     max_try_push_str_benchmark,
-    max_push_str_unchecked_benchmark,
     max_push_str_benchmark,
 );
 criterion_main!(

--- a/benches/string.rs
+++ b/benches/string.rs
@@ -94,6 +94,13 @@ fn small_clone_benchmark(c: &mut Criterion) {
     c.bench_function("small clone", move |b| b.iter(|| string.clone()));
 }
 
+fn small_from_unchecked_benchmark(c: &mut Criterion) {
+    let string = "rrssttuuvvwwxxyyzza";
+    c.bench_function("small from unchecked", move |b| {
+        b.iter(|| unsafe { SmallString::from_str_unchecked(&string) })
+    });
+}
+
 fn small_from_truncate_benchmark(c: &mut Criterion) {
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small from truncate", move |b| {
@@ -105,6 +112,16 @@ fn small_try_from_benchmark(c: &mut Criterion) {
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small try from", move |b| {
         b.iter(|| SmallString::try_from_str(&rand_string))
+    });
+}
+
+fn small_push_str_unchecked_benchmark(c: &mut Criterion) {
+    let mut string = SmallString::default();
+    c.bench_function("small push str unchecked", move |b| {
+        b.iter(|| unsafe {
+            string.push_str_unchecked("1413121110987654321");
+            string.clear();
+        })
     });
 }
 
@@ -149,6 +166,16 @@ fn cache_try_from_benchmark(c: &mut Criterion) {
     });
 }
 
+fn cache_push_str_unchecked_benchmark(c: &mut Criterion) {
+    let mut string = CacheString::default();
+    c.bench_function("cache push str unchecked", move |b| {
+        b.iter(|| unsafe {
+            string.push_str_unchecked("1413121110987654321");
+            string.clear();
+        })
+    });
+}
+
 fn cache_push_str_benchmark(c: &mut Criterion) {
     let mut string = CacheString::default();
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
@@ -176,6 +203,13 @@ fn max_clone_benchmark(c: &mut Criterion) {
     c.bench_function("max clone", move |b| b.iter(|| string.clone()));
 }
 
+fn max_from_unchecked_benchmark(c: &mut Criterion) {
+    let string = "vvvvwwwwxxxxyyyzzzza";
+    c.bench_function("max from unchecked", move |b| {
+        b.iter(|| unsafe { MaxString::from_str_unchecked(&string) })
+    });
+}
+
 fn max_from_truncate_benchmark(c: &mut Criterion) {
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max from truncate", move |b| {
@@ -187,6 +221,16 @@ fn max_try_from_benchmark(c: &mut Criterion) {
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max try from", move |b| {
         b.iter(|| MaxString::try_from_str(&rand_string).unwrap())
+    });
+}
+
+fn max_push_str_unchecked_benchmark(c: &mut Criterion) {
+    let mut string = MaxString::default();
+    c.bench_function("max push str unchecked", move |b| {
+        b.iter(|| unsafe {
+            string.push_str_unchecked("1413121110987654321");
+            string.clear();
+        })
     });
 }
 

--- a/benches/string.rs
+++ b/benches/string.rs
@@ -2,6 +2,8 @@ use arraystring::prelude::*;
 use arrayvec::ArrayString as ArrayVecString;
 use criterion::{criterion_group, criterion_main, Criterion};
 use inlinable_string::{InlinableString, StringExt};
+use rand::distributions::Alphanumeric;
+use rand::{Rng, thread_rng};
 use smallstring::SmallString as SmallVecString;
 
 fn string_clone_benchmark(c: &mut Criterion) {
@@ -10,17 +12,18 @@ fn string_clone_benchmark(c: &mut Criterion) {
 }
 
 fn string_from_benchmark(c: &mut Criterion) {
-    let string = String::from("uvwxyzaabbccddeeffgg");
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("string from", move |b| {
-        b.iter(|| String::from(string.as_str()))
+        b.iter(|| String::from(&rand_string))
     });
 }
 
 fn string_push_str_benchmark(c: &mut Criterion) {
     let mut string = String::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("string push str", move |b| {
         b.iter(|| {
-            string.push_str("0123456789123456789");
+            string.push_str(&rand_string);
             string.clear();
             string.shrink_to_fit();
         })
@@ -33,17 +36,18 @@ fn inlinable_clone_benchmark(c: &mut Criterion) {
 }
 
 fn inlinable_from_benchmark(c: &mut Criterion) {
-    let string = "edauhefhiaw na na  ";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("inlinable from", move |b| {
-        b.iter(|| InlinableString::from(string))
+        b.iter(|| InlinableString::from(rand_string.as_str()))
     });
 }
 
 fn inlinable_push_str_benchmark(c: &mut Criterion) {
     let mut string = InlinableString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("inlinable push str", move |b| {
         b.iter(|| {
-            string.push_str("ddauhifnaoe jaowijd");
+            string.push_str(&rand_string);
             string.clear();
             string.shrink_to_fit();
         })
@@ -56,17 +60,18 @@ fn arrayvec_clone_benchmark(c: &mut Criterion) {
 }
 
 fn arrayvec_from_benchmark(c: &mut Criterion) {
-    let string = "huiaehdishudaishuda";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("arrayvec string from", move |b| {
-        b.iter(|| ArrayVecString::<[u8; 23]>::from(string))
+        b.iter(|| ArrayVecString::<[u8; 23]>::from(&rand_string))
     });
 }
 
 fn arrayvec_push_str_benchmark(c: &mut Criterion) {
     let mut string = ArrayVecString::<[u8; 23]>::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("arrayvec string push str", move |b| {
         b.iter(|| {
-            string.push_str("adasaduhaishdasidha");
+            string.push_str(&rand_string);
             string.clear();
         })
     });
@@ -78,9 +83,9 @@ fn smallvecstring_clone_benchmark(c: &mut Criterion) {
 }
 
 fn smallvecstring_from_benchmark(c: &mut Criterion) {
-    let string = "audshaisdhaisduo8";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("smallvecstring from", move |b| {
-        b.iter(|| SmallVecString::<[u8;20]>::from(string))
+        b.iter(|| SmallVecString::<[u8;20]>::from(rand_string.as_str()))
     });
 }
 
@@ -90,24 +95,25 @@ fn small_clone_benchmark(c: &mut Criterion) {
 }
 
 fn small_from_truncate_benchmark(c: &mut Criterion) {
-    let string = "bbbcccdddeeefffgggh";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small from truncate", move |b| {
-        b.iter(|| SmallString::from_str_truncate(&string))
+        b.iter(|| SmallString::from_str_truncate(&rand_string))
     });
 }
 
 fn small_try_from_benchmark(c: &mut Criterion) {
-    let string = "iiijjjkkklllmmmnnnoo";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small try from", move |b| {
-        b.iter(|| SmallString::try_from_str(&string))
+        b.iter(|| SmallString::try_from_str(&rand_string))
     });
 }
 
 fn small_push_str_benchmark(c: &mut Criterion) {
     let mut string = SmallString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small push str truncate", move |b| {
         b.iter(|| {
-            string.push_str("1413121110987654321");
+            string.push_str(&rand_string);
             string.clear();
         })
     });
@@ -115,9 +121,10 @@ fn small_push_str_benchmark(c: &mut Criterion) {
 
 fn small_try_push_str_benchmark(c: &mut Criterion) {
     let mut string = SmallString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small try push str", move |b| {
         b.iter(|| {
-            string.try_push_str("9897969594939291908").unwrap();
+            string.try_push_str(&rand_string).unwrap();
             string.clear();
         })
     });
@@ -129,24 +136,25 @@ fn cache_clone_benchmark(c: &mut Criterion) {
 }
 
 fn cache_from_truncate_benchmark(c: &mut Criterion) {
-    let string = "ccccddddeeeeffffggggh";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("cache from truncate", move |b| {
-        b.iter(|| CacheString::from_str_truncate(&string))
+        b.iter(|| CacheString::from_str_truncate(&rand_string))
     });
 }
 
 fn cache_try_from_benchmark(c: &mut Criterion) {
-    let string = "iiiijjjjkkkkllllmmmmn";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("cache try from", move |b| {
-        b.iter(|| CacheString::try_from_str(&string))
+        b.iter(|| CacheString::try_from_str(&rand_string))
     });
 }
 
 fn cache_push_str_benchmark(c: &mut Criterion) {
     let mut string = CacheString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("cache push str truncate", move |b| {
         b.iter(|| {
-            string.push_str("1413121110987654321");
+            string.push_str(&rand_string);
             string.clear();
         })
     });
@@ -154,9 +162,10 @@ fn cache_push_str_benchmark(c: &mut Criterion) {
 
 fn cache_try_push_str_benchmark(c: &mut Criterion) {
     let mut string = CacheString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("cache try push str", move |b| {
         b.iter(|| {
-            string.try_push_str("9897969594939291908").unwrap();
+            string.try_push_str(&rand_string).unwrap();
             string.clear();
         })
     });
@@ -168,24 +177,25 @@ fn max_clone_benchmark(c: &mut Criterion) {
 }
 
 fn max_from_truncate_benchmark(c: &mut Criterion) {
-    let string = "bbbbccccddddeeeeffff";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max from truncate", move |b| {
-        b.iter(|| MaxString::from_str_truncate(&string))
+        b.iter(|| MaxString::from_str_truncate(&rand_string))
     });
 }
 
 fn max_try_from_benchmark(c: &mut Criterion) {
-    let string = "gggghhhhiiiijjjjkkkk";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max try from", move |b| {
-        b.iter(|| MaxString::try_from_str(&string).unwrap())
+        b.iter(|| MaxString::try_from_str(&rand_string).unwrap())
     });
 }
 
 fn max_push_str_benchmark(c: &mut Criterion) {
     let mut string = MaxString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max push str truncate", move |b| {
         b.iter(|| {
-            string.push_str("1413121110987654321");
+            string.push_str(&rand_string);
             string.clear();
         })
     });
@@ -193,9 +203,10 @@ fn max_push_str_benchmark(c: &mut Criterion) {
 
 fn max_try_push_str_benchmark(c: &mut Criterion) {
     let mut string = MaxString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max try push str", move |b| {
         b.iter(|| {
-            string.try_push_str("9897969594939291908").unwrap();
+            string.try_push_str(&rand_string).unwrap();
             string.clear();
         })
     });

--- a/benches/string.rs
+++ b/benches/string.rs
@@ -95,9 +95,9 @@ fn small_clone_benchmark(c: &mut Criterion) {
 }
 
 fn small_from_unchecked_benchmark(c: &mut Criterion) {
-    let string = "rrssttuuvvwwxxyyzza";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small from unchecked", move |b| {
-        b.iter(|| unsafe { SmallString::from_str_unchecked(&string) })
+        b.iter(|| unsafe { SmallString::from_str_unchecked(&rand_string) })
     });
 }
 
@@ -117,9 +117,10 @@ fn small_try_from_benchmark(c: &mut Criterion) {
 
 fn small_push_str_unchecked_benchmark(c: &mut Criterion) {
     let mut string = SmallString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("small push str unchecked", move |b| {
         b.iter(|| unsafe {
-            string.push_str_unchecked("1413121110987654321");
+            string.push_str_unchecked(&rand_string);
             string.clear();
         })
     });
@@ -152,6 +153,13 @@ fn cache_clone_benchmark(c: &mut Criterion) {
     c.bench_function("cache clone", move |b| b.iter(|| string.clone()));
 }
 
+fn cache_from_unchecked_benchmark(c: &mut Criterion) {
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
+    c.bench_function("cache from unchecked", move |b| {
+        b.iter(|| unsafe { CacheString::from_str_unchecked(&rand_string) })
+    });
+}
+
 fn cache_from_truncate_benchmark(c: &mut Criterion) {
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("cache from truncate", move |b| {
@@ -168,9 +176,10 @@ fn cache_try_from_benchmark(c: &mut Criterion) {
 
 fn cache_push_str_unchecked_benchmark(c: &mut Criterion) {
     let mut string = CacheString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("cache push str unchecked", move |b| {
         b.iter(|| unsafe {
-            string.push_str_unchecked("1413121110987654321");
+            string.push_str_unchecked(&rand_string);
             string.clear();
         })
     });
@@ -204,9 +213,9 @@ fn max_clone_benchmark(c: &mut Criterion) {
 }
 
 fn max_from_unchecked_benchmark(c: &mut Criterion) {
-    let string = "vvvvwwwwxxxxyyyzzzza";
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max from unchecked", move |b| {
-        b.iter(|| unsafe { MaxString::from_str_unchecked(&string) })
+        b.iter(|| unsafe { MaxString::from_str_unchecked(&rand_string) })
     });
 }
 
@@ -226,9 +235,10 @@ fn max_try_from_benchmark(c: &mut Criterion) {
 
 fn max_push_str_unchecked_benchmark(c: &mut Criterion) {
     let mut string = MaxString::default();
+    let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(19).map(char::from).collect();
     c.bench_function("max push str unchecked", move |b| {
         b.iter(|| unsafe {
-            string.push_str_unchecked("1413121110987654321");
+            string.push_str_unchecked(&rand_string);
             string.clear();
         })
     });
@@ -283,24 +293,30 @@ criterion_group!(
     small,
     small_clone_benchmark,
     small_try_from_benchmark,
+    small_from_unchecked_benchmark,
     small_from_truncate_benchmark,
     small_try_push_str_benchmark,
+    small_push_str_unchecked_benchmark,
     small_push_str_benchmark,
 );
 criterion_group!(
     cache,
     cache_clone_benchmark,
     cache_try_from_benchmark,
+    cache_from_unchecked_benchmark,
     cache_from_truncate_benchmark,
     cache_try_push_str_benchmark,
+    cache_push_str_unchecked_benchmark,
     cache_push_str_benchmark,
 );
 criterion_group!(
     max,
     max_clone_benchmark,
     max_try_from_benchmark,
+    max_from_unchecked_benchmark,
     max_from_truncate_benchmark,
     max_try_push_str_benchmark,
+    max_push_str_unchecked_benchmark,
     max_push_str_benchmark,
 );
 criterion_main!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,34 @@ mod cache_string {
             CacheString(ArrayString::from_str_truncate(string))
         }
 
+        /// Creates new `CacheString` from string slice assuming length is appropriate.
+        ///
+        /// # Safety
+        ///
+        /// It's UB if `string.len()` > [`capacity`].
+        ///
+        /// [`capacity`]: ./struct.CacheString.html#method.capacity
+        ///
+        /// ```rust
+        /// # use arraystring::prelude::*;
+        /// let filled = "0".repeat(CacheString::capacity().into());
+        /// let string = unsafe {
+        ///     CacheString::from_str_unchecked(&filled)
+        /// };
+        /// assert_eq!(string.as_str(), filled.as_str());
+        ///
+        /// // Undefined behavior, don't do it
+        /// // let out_of_bounds = "0".repeat(CacheString::capacity().into() + 1);
+        /// // let ub = unsafe { CacheString::from_str_unchecked(out_of_bounds) };
+        /// ```
+        #[inline]
+        pub unsafe fn from_str_unchecked<S>(string: S) -> Self
+        where
+            S: AsRef<str>,
+        {
+            CacheString(ArrayString::from_str_unchecked(string))
+        }
+
         /// Creates new `CacheString` from string slice iterator if total length is lower or equal to [`capacity`], otherwise returns an error.
         ///
         /// [`capacity`]: ./struct.CacheString.html#method.capacity
@@ -338,6 +366,36 @@ mod cache_string {
             CacheString(ArrayString::from_iterator(iter))
         }
 
+        /// Creates new `CacheString` from string slice iterator assuming length is appropriate.
+        ///
+        /// # Safety
+        ///
+        /// It's UB if `iter.map(|c| c.len()).sum()` > [`capacity`].
+        ///
+        /// [`capacity`]: ./struct.CacheString.html#method.capacity
+        ///
+        /// ```rust
+        /// # use arraystring::prelude::*;
+        /// let string = unsafe {
+        ///     CacheString::from_iterator_unchecked(&["My String", " My Other String"][..])
+        /// };
+        /// assert_eq!(string.as_str(), "My String My Other String");
+        ///
+        /// // Undefined behavior, don't do it
+        /// // let out_of_bounds = (0..400).map(|_| "000");
+        /// // let undefined_behavior = unsafe {
+        /// //     CacheString::from_iterator_unchecked(out_of_bounds)
+        /// // };
+        /// ```
+        #[inline]
+        pub unsafe fn from_iterator_unchecked<U, I>(iter: I) -> Self
+        where
+            U: AsRef<str>,
+            I: IntoIterator<Item = U>,
+        {
+            CacheString(ArrayString::from_iterator_unchecked(iter))
+        }
+
         /// Creates new `CacheString` from char iterator if total length is lower or equal to [`capacity`], otherwise returns an error.
         ///
         /// [`capacity`]: ./struct.CacheString.html#method.capacity
@@ -384,6 +442,31 @@ mod cache_string {
             I: IntoIterator<Item = char>,
         {
             CacheString(ArrayString::from_chars(iter))
+        }
+
+        /// Creates new `CacheString` from char iterator assuming length is appropriate.
+        ///
+        /// # Safety
+        ///
+        /// It's UB if `iter.map(|c| c.len_utf8()).sum()` > [`capacity`].
+        ///
+        /// [`capacity`]: ./struct.CacheString.html#method.capacity
+        ///
+        /// ```rust
+        /// # use arraystring::prelude::*;
+        /// let string = unsafe { CacheString::from_chars_unchecked("My String".chars()) };
+        /// assert_eq!(string.as_str(), "My String");
+        ///
+        /// // Undefined behavior, don't do it
+        /// // let out_of_bounds = "000".repeat(400);
+        /// // let undefined_behavior = unsafe { CacheString::from_chars_unchecked(out_of_bounds.chars()) };
+        /// ```
+        #[inline]
+        pub unsafe fn from_chars_unchecked<I>(iter: I) -> Self
+        where
+            I: IntoIterator<Item = char>,
+        {
+            CacheString(ArrayString::from_chars_unchecked(iter))
         }
 
         /// Creates new `CacheString` from byte slice, returning [`Utf8`] on invalid utf-8 data or [`OutOfBounds`] if bigger than [`capacity`]
@@ -442,6 +525,31 @@ mod cache_string {
             B: AsRef<[u8]>,
         {
             Ok(CacheString(ArrayString::from_utf8(slice)?))
+        }
+
+        /// Creates new `CacheString` from byte slice assuming it's utf-8 and of a appropriate size.
+        ///
+        /// # Safety
+        ///
+        /// It's UB if `slice` is not a valid utf-8 string or `slice.len()` > [`capacity`].
+        ///
+        /// [`capacity`]: ./struct.CacheString.html#method.capacity
+        ///
+        /// ```rust
+        /// # use arraystring::prelude::*;
+        /// let string = unsafe { CacheString::from_utf8_unchecked("My String") };
+        /// assert_eq!(string.as_str(), "My String");
+        ///
+        /// // Undefined behavior, don't do it
+        /// // let out_of_bounds = "0".repeat(300);
+        /// // let ub = unsafe { CacheString::from_utf8_unchecked(out_of_bounds)) };
+        /// ```
+        #[inline]
+        pub unsafe fn from_utf8_unchecked<B>(slice: B) -> Self
+        where
+            B: AsRef<[u8]>,
+        {
+            CacheString(ArrayString::from_utf8_unchecked(slice))
         }
 
         /// Creates new `CacheString` from `u16` slice, returning [`Utf16`] on invalid utf-16 data or [`OutOfBounds`] if bigger than [`capacity`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,34 +286,6 @@ mod cache_string {
             CacheString(ArrayString::from_str_truncate(string))
         }
 
-        /// Creates new `CacheString` from string slice assuming length is appropriate.
-        ///
-        /// # Safety
-        ///
-        /// It's UB if `string.len()` > [`capacity`].
-        ///
-        /// [`capacity`]: ./struct.CacheString.html#method.capacity
-        ///
-        /// ```rust
-        /// # use arraystring::prelude::*;
-        /// let filled = "0".repeat(CacheString::capacity().into());
-        /// let string = unsafe {
-        ///     CacheString::from_str_unchecked(&filled)
-        /// };
-        /// assert_eq!(string.as_str(), filled.as_str());
-        ///
-        /// // Undefined behavior, don't do it
-        /// // let out_of_bounds = "0".repeat(CacheString::capacity().into() + 1);
-        /// // let ub = unsafe { CacheString::from_str_unchecked(out_of_bounds) };
-        /// ```
-        #[inline]
-        pub unsafe fn from_str_unchecked<S>(string: S) -> Self
-        where
-            S: AsRef<str>,
-        {
-            CacheString(ArrayString::from_str_unchecked(string))
-        }
-
         /// Creates new `CacheString` from string slice iterator if total length is lower or equal to [`capacity`], otherwise returns an error.
         ///
         /// [`capacity`]: ./struct.CacheString.html#method.capacity
@@ -366,36 +338,6 @@ mod cache_string {
             CacheString(ArrayString::from_iterator(iter))
         }
 
-        /// Creates new `CacheString` from string slice iterator assuming length is appropriate.
-        ///
-        /// # Safety
-        ///
-        /// It's UB if `iter.map(|c| c.len()).sum()` > [`capacity`].
-        ///
-        /// [`capacity`]: ./struct.CacheString.html#method.capacity
-        ///
-        /// ```rust
-        /// # use arraystring::prelude::*;
-        /// let string = unsafe {
-        ///     CacheString::from_iterator_unchecked(&["My String", " My Other String"][..])
-        /// };
-        /// assert_eq!(string.as_str(), "My String My Other String");
-        ///
-        /// // Undefined behavior, don't do it
-        /// // let out_of_bounds = (0..400).map(|_| "000");
-        /// // let undefined_behavior = unsafe {
-        /// //     CacheString::from_iterator_unchecked(out_of_bounds)
-        /// // };
-        /// ```
-        #[inline]
-        pub unsafe fn from_iterator_unchecked<U, I>(iter: I) -> Self
-        where
-            U: AsRef<str>,
-            I: IntoIterator<Item = U>,
-        {
-            CacheString(ArrayString::from_iterator_unchecked(iter))
-        }
-
         /// Creates new `CacheString` from char iterator if total length is lower or equal to [`capacity`], otherwise returns an error.
         ///
         /// [`capacity`]: ./struct.CacheString.html#method.capacity
@@ -442,31 +384,6 @@ mod cache_string {
             I: IntoIterator<Item = char>,
         {
             CacheString(ArrayString::from_chars(iter))
-        }
-
-        /// Creates new `CacheString` from char iterator assuming length is appropriate.
-        ///
-        /// # Safety
-        ///
-        /// It's UB if `iter.map(|c| c.len_utf8()).sum()` > [`capacity`].
-        ///
-        /// [`capacity`]: ./struct.CacheString.html#method.capacity
-        ///
-        /// ```rust
-        /// # use arraystring::prelude::*;
-        /// let string = unsafe { CacheString::from_chars_unchecked("My String".chars()) };
-        /// assert_eq!(string.as_str(), "My String");
-        ///
-        /// // Undefined behavior, don't do it
-        /// // let out_of_bounds = "000".repeat(400);
-        /// // let undefined_behavior = unsafe { CacheString::from_chars_unchecked(out_of_bounds.chars()) };
-        /// ```
-        #[inline]
-        pub unsafe fn from_chars_unchecked<I>(iter: I) -> Self
-        where
-            I: IntoIterator<Item = char>,
-        {
-            CacheString(ArrayString::from_chars_unchecked(iter))
         }
 
         /// Creates new `CacheString` from byte slice, returning [`Utf8`] on invalid utf-8 data or [`OutOfBounds`] if bigger than [`capacity`]
@@ -525,31 +442,6 @@ mod cache_string {
             B: AsRef<[u8]>,
         {
             Ok(CacheString(ArrayString::from_utf8(slice)?))
-        }
-
-        /// Creates new `CacheString` from byte slice assuming it's utf-8 and of a appropriate size.
-        ///
-        /// # Safety
-        ///
-        /// It's UB if `slice` is not a valid utf-8 string or `slice.len()` > [`capacity`].
-        ///
-        /// [`capacity`]: ./struct.CacheString.html#method.capacity
-        ///
-        /// ```rust
-        /// # use arraystring::prelude::*;
-        /// let string = unsafe { CacheString::from_utf8_unchecked("My String") };
-        /// assert_eq!(string.as_str(), "My String");
-        ///
-        /// // Undefined behavior, don't do it
-        /// // let out_of_bounds = "0".repeat(300);
-        /// // let ub = unsafe { CacheString::from_utf8_unchecked(out_of_bounds)) };
-        /// ```
-        #[inline]
-        pub unsafe fn from_utf8_unchecked<B>(slice: B) -> Self
-        where
-            B: AsRef<[u8]>,
-        {
-            CacheString(ArrayString::from_utf8_unchecked(slice))
         }
 
         /// Creates new `CacheString` from `u16` slice, returning [`Utf16`] on invalid utf-16 data or [`OutOfBounds`] if bigger than [`capacity`]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -143,11 +143,23 @@ pub fn is_char_boundary<const N: usize>(s: &ArrayString<N>, idx: u8) -> Result<(
 /// Truncates string to specified size (ignoring last bytes if they form a partial `char`)
 #[inline]
 pub(crate) fn truncate_str(slice: &str, size: u8) -> &str {
-    let mut index = size as usize;
-    while !slice.is_char_boundary(index) {
-        index = index.saturating_sub(1);
+    trace!("Truncate str: {} at {}", slice, size);
+    let mut size = size as usize;
+    if slice.is_char_boundary(size) {
+        return unsafe { slice.get_unchecked(..size) }
+    } else if size >= slice.len() {
+        return slice;
     }
-    unsafe { slice.get_unchecked(..index) }
+    size -= 1;
+    if slice.is_char_boundary(size) {
+        return unsafe { slice.get_unchecked(..size) }
+    }
+    size -= 1;
+    if slice.is_char_boundary(size) {
+        return unsafe { slice.get_unchecked(..size) }
+    }
+    size -= 1;
+    unsafe { slice.get_unchecked(..size) }
 }
 
 impl IntoLossy<u8> for usize {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,6 +22,18 @@ pub(crate) unsafe fn never(s: &str) -> ! {
     core::hint::unreachable_unchecked()
 }
 
+/// Encodes `char` into `ArrayString` at specified position, heavily unsafe
+///
+/// We reimplement the `core` function to avoid panicking (UB instead, be careful)
+///
+/// Reimplemented from:
+///
+/// `https://github.com/rust-lang/rust/blob/7843e2792dce0f20d23b3c1cca51652013bef0ea/src/libcore/char/methods.rs#L447`
+/// # Safety
+///
+/// - It's UB if index is outside of buffer's boundaries (buffer needs at most 4 bytes)
+/// - It's UB if index is inside a character (like a index 3 for "a🤔")
+#[inline]
 pub(crate) unsafe fn encode_char_utf8_unchecked<const N: usize>(
     s: &mut ArrayString<N>,
     ch: char,
@@ -95,9 +107,9 @@ unsafe fn shift_unchecked(s: &mut [u8], from: usize, to: usize, len: usize) {
 /// [`<S as Unsigned>::to_u8()`]: ../struct.ArrayString.html#CAPACITY
 #[inline]
 pub(crate) unsafe fn shift_right_unchecked<const N: usize, F, T>(s: &mut ArrayString<N>, from: F, to: T)
-    where
-        F: Into<usize> + Copy,
-        T: Into<usize> + Copy,
+where
+    F: Into<usize> + Copy,
+    T: Into<usize> + Copy,
 {
     let len = (s.len() as usize).saturating_sub(from.into());
     debug_assert!(from.into() <= to.into() && to.into().saturating_add(len) <= N);
@@ -108,9 +120,9 @@ pub(crate) unsafe fn shift_right_unchecked<const N: usize, F, T>(s: &mut ArraySt
 /// Shifts string left
 #[inline]
 pub(crate) unsafe fn shift_left_unchecked<const N: usize, F, T>(s: &mut ArrayString<N>, from: F, to: T)
-    where
-        F: Into<usize> + Copy,
-        T: Into<usize> + Copy,
+where
+    F: Into<usize> + Copy,
+    T: Into<usize> + Copy,
 {
     debug_assert!(to.into() <= from.into() && from.into() <= s.len().into());
     debug_assert!(s.as_str().is_char_boundary(from.into()));
@@ -122,9 +134,9 @@ pub(crate) unsafe fn shift_left_unchecked<const N: usize, F, T>(s: &mut ArrayStr
 /// Returns error if size is outside of specified boundary
 #[inline]
 pub fn is_inside_boundary<S, L>(size: S, limit: L) -> Result<(), OutOfBounds>
-    where
-        S: Into<usize>,
-        L: Into<usize>,
+where
+    S: Into<usize>,
+    L: Into<usize>,
 {
     let (s, l) = (size.into(), limit.into());
     (s <= l).then_some(()).ok_or(OutOfBounds)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,24 +22,21 @@ pub(crate) unsafe fn never(s: &str) -> ! {
     core::hint::unreachable_unchecked()
 }
 
-/// Encodes `char` into `ArrayString` at specified position, heavily unsafe
-///
-/// We reimplement the `core` function to avoid panicking (UB instead, be careful)
-///
-/// Reimplemented from:
-///
-/// `https://github.com/rust-lang/rust/blob/7843e2792dce0f20d23b3c1cca51652013bef0ea/src/libcore/char/methods.rs#L447`
-/// # Safety
-///
-/// - It's UB if index is outside of buffer's boundaries (buffer needs at most 4 bytes)
-/// - It's UB if index is inside a character (like a index 3 for "a🤔")
-#[inline]
 pub(crate) unsafe fn encode_char_utf8_unchecked<const N: usize>(
     s: &mut ArrayString<N>,
     ch: char,
     index: u8,
-) {
-    // UTF-8 ranges and tags for encoding characters
+) -> usize {
+    append_char_truncate(s.array.get_unchecked_mut(index as usize..), ch)
+}
+
+/// Encodes `char` into `&mut [u8]` and returns written length
+#[inline]
+pub(crate) fn append_char_truncate(
+    dst: &mut [u8],
+    code: char,
+) -> usize {
+
     #[allow(clippy::missing_docs_in_private_items)]
     const TAG_CONT: u8 = 0b1000_0000;
     #[allow(clippy::missing_docs_in_private_items)]
@@ -48,39 +45,31 @@ pub(crate) unsafe fn encode_char_utf8_unchecked<const N: usize>(
     const TAG_THREE_B: u8 = 0b1110_0000;
     #[allow(clippy::missing_docs_in_private_items)]
     const TAG_FOUR_B: u8 = 0b1111_0000;
-    #[allow(clippy::missing_docs_in_private_items)]
-    const MAX_ONE_B: u32 = 0x80;
-    #[allow(clippy::missing_docs_in_private_items)]
-    const MAX_TWO_B: u32 = 0x800;
-    #[allow(clippy::missing_docs_in_private_items)]
-    const MAX_THREE_B: u32 = 0x10000;
 
-    trace!("Encode char: {} to {}", ch, index);
-
-    debug_assert!(ch.len_utf8().saturating_add(index.into()) <= N);
-    debug_assert!(ch.len_utf8().saturating_add(s.len().into()) <= N);
-    let dst = s.array.as_mut_slice().get_unchecked_mut(index.into()..);
-    let code = ch as u32;
-
-    if code < MAX_ONE_B {
-        debug_assert!(!dst.is_empty());
-        *dst.get_unchecked_mut(0) = code.into_lossy();
-    } else if code < MAX_TWO_B {
-        debug_assert!(dst.len() >= 2);
-        *dst.get_unchecked_mut(0) = (code >> 6 & 0x1F).into_lossy() | TAG_TWO_B;
-        *dst.get_unchecked_mut(1) = (code & 0x3F).into_lossy() | TAG_CONT;
-    } else if code < MAX_THREE_B {
-        debug_assert!(dst.len() >= 3);
-        *dst.get_unchecked_mut(0) = (code >> 12 & 0x0F).into_lossy() | TAG_THREE_B;
-        *dst.get_unchecked_mut(1) = (code >> 6 & 0x3F).into_lossy() | TAG_CONT;
-        *dst.get_unchecked_mut(2) = (code & 0x3F).into_lossy() | TAG_CONT;
-    } else {
-        debug_assert!(dst.len() >= 4);
-        *dst.get_unchecked_mut(0) = (code >> 18 & 0x07).into_lossy() | TAG_FOUR_B;
-        *dst.get_unchecked_mut(1) = (code >> 12 & 0x3F).into_lossy() | TAG_CONT;
-        *dst.get_unchecked_mut(2) = (code >> 6 & 0x3F).into_lossy() | TAG_CONT;
-        *dst.get_unchecked_mut(3) = (code & 0x3F).into_lossy() | TAG_CONT;
-    }
+    let len = code.len_utf8();
+    let code = code as u32;
+    match (len, &mut dst[..]) {
+        (1, [a, ..]) => {
+            *a = code as u8;
+        }
+        (2, [a, b, ..]) => {
+            *a = (code >> 6 & 0x1F) as u8 | TAG_TWO_B;
+            *b = (code & 0x3F) as u8 | TAG_CONT;
+        }
+        (3, [a, b, c, ..]) => {
+            *a = (code >> 12 & 0x0F) as u8 | TAG_THREE_B;
+            *b = (code >> 6 & 0x3F) as u8 | TAG_CONT;
+            *c = (code & 0x3F) as u8 | TAG_CONT;
+        }
+        (4, [a, b, c, d, ..]) => {
+            *a = (code >> 18 & 0x07) as u8 | TAG_FOUR_B;
+            *b = (code >> 12 & 0x3F) as u8 | TAG_CONT;
+            *c = (code >> 6 & 0x3F) as u8 | TAG_CONT;
+            *d = (code & 0x3F) as u8 | TAG_CONT;
+        }
+        _ => return 0,
+    };
+    len
 }
 
 /// Copies part of slice to another part (`mem::copy`, basically `memmove`)
@@ -106,9 +95,9 @@ unsafe fn shift_unchecked(s: &mut [u8], from: usize, to: usize, len: usize) {
 /// [`<S as Unsigned>::to_u8()`]: ../struct.ArrayString.html#CAPACITY
 #[inline]
 pub(crate) unsafe fn shift_right_unchecked<const N: usize, F, T>(s: &mut ArrayString<N>, from: F, to: T)
-where
-    F: Into<usize> + Copy,
-    T: Into<usize> + Copy,
+    where
+        F: Into<usize> + Copy,
+        T: Into<usize> + Copy,
 {
     let len = (s.len() as usize).saturating_sub(from.into());
     debug_assert!(from.into() <= to.into() && to.into().saturating_add(len) <= N);
@@ -119,9 +108,9 @@ where
 /// Shifts string left
 #[inline]
 pub(crate) unsafe fn shift_left_unchecked<const N: usize, F, T>(s: &mut ArrayString<N>, from: F, to: T)
-where
-    F: Into<usize> + Copy,
-    T: Into<usize> + Copy,
+    where
+        F: Into<usize> + Copy,
+        T: Into<usize> + Copy,
 {
     debug_assert!(to.into() <= from.into() && from.into() <= s.len().into());
     debug_assert!(s.as_str().is_char_boundary(from.into()));
@@ -133,13 +122,12 @@ where
 /// Returns error if size is outside of specified boundary
 #[inline]
 pub fn is_inside_boundary<S, L>(size: S, limit: L) -> Result<(), OutOfBounds>
-where
-    S: Into<usize>,
-    L: Into<usize>,
+    where
+        S: Into<usize>,
+        L: Into<usize>,
 {
     let (s, l) = (size.into(), limit.into());
-    trace!("Out of bounds: ensures {} < {}", s, l);
-    Some(()).filter(|_| s <= l).ok_or(OutOfBounds)
+    (s <= l).then_some(()).ok_or(OutOfBounds)
 }
 
 /// Returns error if index is not at a valid utf-8 char boundary
@@ -155,18 +143,11 @@ pub fn is_char_boundary<const N: usize>(s: &ArrayString<N>, idx: u8) -> Result<(
 /// Truncates string to specified size (ignoring last bytes if they form a partial `char`)
 #[inline]
 pub(crate) fn truncate_str(slice: &str, size: u8) -> &str {
-    trace!("Truncate str: {} at {}", slice, size);
-    if slice.is_char_boundary(size.into()) {
-        unsafe { slice.get_unchecked(..size.into()) }
-    } else if (size as usize) < slice.len() {
-        let mut index = size.saturating_sub(1) as usize;
-        while !slice.is_char_boundary(index) {
-            index = index.saturating_sub(1);
-        }
-        unsafe { slice.get_unchecked(..index) }
-    } else {
-        slice
+    let mut index = size as usize;
+    while !slice.is_char_boundary(index) {
+        index = index.saturating_sub(1);
     }
+    unsafe { slice.get_unchecked(..index) }
 }
 
 impl IntoLossy<u8> for usize {
@@ -230,11 +211,11 @@ mod tests {
         let _ = env_logger::try_init();
         let mut string = SmallString::default();
         unsafe {
-            encode_char_utf8_unchecked(&mut string, 'a', 0);
+            let _ = encode_char_utf8_unchecked(&mut string, 'a', 0);
             assert_eq!(from_utf8(&string.array.as_mut_slice()[..1]).unwrap(), "a");
             let mut string = SmallString::try_from_str("a").unwrap();
 
-            encode_char_utf8_unchecked(&mut string, '🤔', 1);
+            let _ = encode_char_utf8_unchecked(&mut string, '🤔', 1);
             assert_eq!(from_utf8(&string.array.as_mut_slice()[..5]).unwrap(), "a🤔");
         }
     }

--- a/tests/string_parity.rs
+++ b/tests/string_parity.rs
@@ -31,13 +31,6 @@ fn from_str_truncate() {
 }
 
 #[test]
-fn from_str_unchecked() {
-    assert(String::from, |s| unsafe {
-        MaxString::from_str_unchecked(s)
-    });
-}
-
-#[test]
 fn try_from_chars() {
     assert(
         |s| String::from_iter(s.chars()),
@@ -54,14 +47,6 @@ fn from_chars() {
 }
 
 #[test]
-fn from_chars_unchecked() {
-    assert(
-        |s| String::from_iter(s.chars()),
-        |s| unsafe { MaxString::from_chars_unchecked(s.chars()) },
-    );
-}
-
-#[test]
 fn try_from_iter() {
     assert(
         |s| String::from_iter(vec![s]),
@@ -74,14 +59,6 @@ fn from_iter() {
     assert(
         |s| String::from_iter(vec![s]),
         |s| MaxString::from_iterator(vec![s]),
-    );
-}
-
-#[test]
-fn from_iter_unchecked() {
-    assert(
-        |s| String::from_iter(vec![s]),
-        |s| unsafe { MaxString::from_iterator_unchecked(vec![s]) },
     );
 }
 
@@ -200,16 +177,6 @@ fn from_utf16_lossy_invalid() {
 }
 
 #[test]
-fn from_utf8_unchecked() {
-    unsafe {
-        assert(
-            |s| String::from_utf8_unchecked(s.as_bytes().to_vec()),
-            |s| MaxString::from_utf8_unchecked(s.as_bytes()),
-        );
-    }
-}
-
-#[test]
 fn try_push_str() {
     assert(
         |s| {
@@ -248,21 +215,6 @@ fn add_str() {
     );
 }
 
-#[test]
-fn push_str_unchecked() {
-    assert(
-        |s| {
-            let mut st = String::from(s);
-            st.push_str(s);
-            st
-        },
-        |s| {
-            let mut ms = MaxString::try_from_str(s).unwrap();
-            unsafe { ms.push_str_unchecked(s) };
-            ms
-        },
-    );
-}
 
 #[test]
 fn push() {
@@ -275,22 +227,6 @@ fn push() {
         |s| {
             let mut ms = MaxString::try_from_str(s).unwrap();
             ms.try_push('🤔').map(|()| ms)
-        },
-    );
-}
-
-#[test]
-fn push_unchecked() {
-    assert(
-        |s| {
-            let mut s = String::from(s);
-            s.push('🤔');
-            s
-        },
-        |s| {
-            let mut ms = MaxString::try_from_str(s).unwrap();
-            unsafe { ms.push_unchecked('🤔') };
-            ms
         },
     );
 }


### PR DESCRIPTION
- removed lots of unchecked function with negligible performance impact (+-2%)
- improved truncate_str 50% to 90%
- made a safe version of `encode_char_utf8_unchecked` called `append_char_truncate` that operates on &mut [u8]

best to verify benches, it could be platform specific