### PR TITLE
changed truncate to unrolled version

### DIFF
--- a/src/arraystring.rs
+++ b/src/arraystring.rs
@@ -605,7 +605,7 @@ where
     pub fn push_str_truncate(&mut self, string: impl AsRef<str>) {
         trace!("Push str truncate: {}", string.as_ref());
         let size = Self::capacity().saturating_sub(self.len());
-        unsafe { self.push_str_unchecked(truncate_str(string.as_ref(), size)) }
+        unsafe { self.push_str_unchecked(truncate_str(string.as_ref(), size as usize)) }
     }
 
     /// Pushes string slice to the end of the `ArrayString` assuming total size is appropriate.
@@ -972,7 +972,7 @@ where
         is_inside_boundary(idx, self.len())?;
         is_char_boundary(self, idx)?;
         let size = Self::capacity().saturating_sub(self.len());
-        unsafe { self.insert_str_unchecked(idx, truncate_str(string.as_ref(), size)) };
+        unsafe { self.insert_str_unchecked(idx, truncate_str(string.as_ref(), size as usize)) };
         Ok(())
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -167,18 +167,25 @@ where
 
 /// Truncates string to specified size (ignoring last bytes if they form a partial `char`)
 #[inline]
-pub(crate) fn truncate_str(slice: &str, size: u8) -> &str {
+pub(crate) fn truncate_str(slice: &str, mut size: usize) -> &str {
     trace!("Truncate str: {} at {}", slice, size);
-    if slice.is_char_boundary(size.into()) {
-        unsafe { slice.get_unchecked(..size.into()) }
-    } else if (size as usize) < slice.len() {
-        let mut index = size.saturating_sub(1) as usize;
-        while !slice.is_char_boundary(index) {
-            index = index.saturating_sub(1);
+    if size >= slice.len() {
+        return slice;
+    }
+    unsafe {
+        if slice.is_char_boundary(size) {
+            return slice.get_unchecked(..size);
         }
-        unsafe { slice.get_unchecked(..index) }
-    } else {
-        slice
+        size -= 1;
+        if slice.is_char_boundary(size) {
+            return slice.get_unchecked(..size);
+        }
+        size -= 1;
+        if slice.is_char_boundary(size) {
+            return slice.get_unchecked(..size);
+        }
+        size -= 1;
+        slice.get_unchecked(..size)
     }
 }
 


### PR DESCRIPTION
- Changed truncate to unrolled version

equal to master with 1 and 2 bytes, faster with 3 and 4.

the bits version would be even faster on 3 and 4 but they are so rare the overhead for 1 byte is not worth it.

tests don't pass because they don't pass on master either.